### PR TITLE
Allow React dependency to accept patch updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "prelude-extension": "0.0.5",
     "prelude-ls": "^1.1.1",
-    "react": "0.14.0",
+    "react": "^0.14.0",
     "react-addons-css-transition-group": "^0.14.0",
     "react-dom": "^0.14.0"
   },


### PR DESCRIPTION
The `package.json` has its React dependency locked down to `0.14.0` but the `react-dom` and `react-addons-css-transition-group` packages are both set to `^0.14.0`, meaning they'll accept patch releases. It  looks like this results in React 0.14.0 getting installed alongside `react-addons-test-utils` 0.14.1, which wants a peerDependency React version of 0.14.1 or higher, breaking things.

This PR attempts to fix it by setting the React dependency to also accept patch releases. I would imagine it could also be fixed by locking the other two packages down to 0.14.0 if that was preferred.
